### PR TITLE
fewer logs + sanitize a little

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -12,9 +12,8 @@ from comet_ml import Experiment  # keep before pytorch
 
 import torch
 import torch.backends.cudnn as cudnn
-from torch.autograd import Variable
 
-from inception_utils import load_inception_net, prepare_inception_metrics
+from inception_utils import prepare_inception_metrics
 from trainer import MUNIT_Trainer
 from utils import (
     Timer,
@@ -27,7 +26,6 @@ from utils import (
     get_synthetic_data_loader,
     prepare_sub_folder,
     write_2images,
-    write_loss,
 )
 
 try:
@@ -70,10 +68,8 @@ if comet_exp is not None:
 # Setup model and data loader
 if opts.trainer == "MUNIT":
     trainer = MUNIT_Trainer(config)
-elif opts.trainer == "UNIT":
-    trainer = UNIT_Trainer(config)
 else:
-    sys.exit("Only support MUNIT|UNIT")
+    sys.exit("Only support MUNIT")
 trainer.cuda()
 
 train_loader_a, train_loader_b, test_loader_a, test_loader_b = get_all_data_loaders(

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -313,7 +313,7 @@ class MyDataset(Dataset):
 
         if type(mask) is not torch.Tensor:
             # Resize mask
-            if flip == True:
+            if flip is True:
                 mask = mask.transpose(Image.FLIP_LEFT_RIGHT)
 
             mask = mask.resize((image.width, image.height), Image.NEAREST)
@@ -957,8 +957,8 @@ class Resnet34_8s(nn.Module):
     def forward(self, x, feature_alignment=False):
         input_spatial_dim = x.size()[2:]
 
-        if feature_alignment:
-            x = adjust_input_image_size_for_proper_feature_alignment(x, output_stride=8)
+        # if feature_alignment:
+        #     x = adjust_input_image_size_for_proper_feature_alignment(x, output_stride=8)
 
         x = self.resnet34_8s(x)
 
@@ -1036,7 +1036,9 @@ def load_inception(model_path):
         model -- Inception model
     """
     state_dict = torch.load(model_path)
-    model = inception_v3(pretrained=False, transform_input=True)
+    model = inception_v3(
+        pretrained=False, transform_input=True
+    )  #! undefined inceptionv3
     model.aux_logits = False
     num_ftrs = model.fc.in_features
     model.fc = nn.Linear(num_ftrs, state_dict["fc.weight"].size(0))


### PR DESCRIPTION
Only log losses every 100 iterations, anything more is overkill & useless, probably slows down a little (but for 100s of 1000s of iters it can account for something) + may be the source of missing data in comet

+ remove unused imports